### PR TITLE
Example file disease.py sample_size update, copacar fsz tweak

### DIFF
--- a/copacar/copacar.py
+++ b/copacar/copacar.py
@@ -144,7 +144,7 @@ def copacar(X, rank, **kwargs):
     # ------ initialize indices ----------------------------------------------
     e = X[0].shape[0]
     SZ = e * e
-    fsz = min(sample_size, SZ / sample_size)
+    fsz = min(sample_size, SZ // sample_size)
 
     indices1 = zip(*[np.where(X[i] == 0) for i in range(len(X))])
     indices1 = [np.concatenate(ind) for ind in indices1]

--- a/examples/diseases.py
+++ b/examples/diseases.py
@@ -15,7 +15,7 @@ def predict_copacar_sgd(T):
     A, R, _, _, = copacar_sgd(
         T, 10, conv=0.1, lambda_A=0,
         lambda_R=0, n_jobs=2,
-        max_iter=20, sample_size=100,
+        max_iter=20, sample_size=500,
     )
     n = A.shape[0]
     P = np.zeros((n, n, len(R)))


### PR DESCRIPTION
This branch includes two very simple tweaks:

A) In disease.py, a sample_size=100 results in lower AUC scores (~0.65). Increasing sample_size to 500 results in AUC scores of 0.90+

B) I noticed that when running copacar.py alone so that main() runs results in an TypeError on line 168 since fsz is a float but is used in a numpy array offset when an integer is expected. I changed float division (/) to integer division (//) for fsz = min(...). I am using Numpy 1.10.2 and Python 3.4.
